### PR TITLE
Duplicate detection add releases

### DIFF
--- a/Releases/releases/ReleasesApp/templates/releases/add_release.html
+++ b/Releases/releases/ReleasesApp/templates/releases/add_release.html
@@ -20,7 +20,7 @@
             <input class="form-control" type="text" name="title" placeholder="TITLE">
         </div>
         <div class="form-group">
-            <input class="form-control" type="date" name="release_date" placeholder="DATE">
+            <input class="form-control" type="date" name="release_date">
         </div>
         <input class="btn btn-primary" type="submit" value="Register">
     </form>

--- a/Releases/releases/ReleasesApp/views.py
+++ b/Releases/releases/ReleasesApp/views.py
@@ -109,11 +109,26 @@ def logout_view(request):
 
 def add_release(request):
     if request.method == "POST":
+        
+        releasedate=request.POST["release_date"]
+        artist=request.POST["artist"]
+        title=request.POST["title"]
+
+        occurance = Release.objects.filter(release_date=releasedate, artist=artist).count()
+        occurance += Release.objects.filter(artist=artist, title=title).count() 
+        occurance += Release.objects.filter(title=title, release_date=releasedate).count()
+
+        if occurance > 0:
+            return render(request, "releases/add_release.html", ({
+                "message": "This release exists already"
+            }))
+
         data = {
-            "release_date": request.POST["release_date"],
-            "artist": request.POST["artist"],
-            "title": request.POST["title"]
+            "release_date": releasedate,
+            "artist": artist,
+            "title": title
         }
+        
 
         requests.post('http://127.0.0.1:8000/restapi/releases/', data, auth=('ADMIN', 'ADMIN'))
         return HttpResponseRedirect(reverse("releases"))


### PR DESCRIPTION
When you add a release through the AddRelease page, you won't be able to submit a release that's already in de database.

We check if there are 2 fields the same as a release that has been submitted already. This way, we also leave space to filter out typo's and other faults in 1 of the fields.

When a user submits a release that exists already, with 2 mistakes in its entry, it will be submitted anyway.